### PR TITLE
Add ClearML Logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ on your local system.
 [training.logger]
 @loggers = "spacy.ClearMLLogger.v1"
 project_name = "Hello ClearML!"
+task_name = "My spaCy Task"
 model_log_interval = 1000
 log_best_dir = training/model-best
 log_latest_dir = training/model-last
@@ -201,7 +202,7 @@ remove_config_values = ["paths.train", "paths.dev", "corpora.train.path", "corpo
 | Name                   | Type            | Description                                                                                                                                                                                                                     |
 | ---------------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `project_name`         | `str`           | The name of the project in the ClearML interface. The project will be created automatically if it doesn't exist yet.                                                                                                            |
-| `task_name`            | `Optional[str]` | The name of the ClearML task. A task is an experiment that lives inside a project. Can be non-unique. (default: `spaCy Training`).                                                                                              |
+| `task_name`            | `str`           | The name of the ClearML task. A task is an experiment that lives inside a project. Can be non-unique.                                                                                                                           |
 | `remove_config_values` | `List[str]`     | A list of values to exclude from the config before it is uploaded to ClearML (default: `[]`).                                                                                                                                   |
 | `model_log_interval`   | `Optional[int]` | Steps to wait between logging model checkpoints to the ClearML dasboard (default: `None`). Will have no effect without also setting `log_best_dir` or `log_latest_dir`.                                                         |
 | `log_best_dir`         | `Optional[str]` | Directory containing the best trained model as saved by spaCy (by default in `training/model-best`), to be logged and versioned as a ClearML artifact (default: `None`)                                                         |

--- a/README.md
+++ b/README.md
@@ -158,27 +158,28 @@ clearml-init
 using the [ClearML](https://www.clear.ml/) tool. To use
 this logger, ClearML should be installed and you should have initialized (using the command above).
 The logger will send all the gathered information to your ClearML server, either [the hosted free tier](https://app.clear.ml) 
-or the open source [self-hosted server](https://github.com/allegroai/clearml-server). This logger captures all the following information (all visible in the web UI):
+or the open source [self-hosted server](https://github.com/allegroai/clearml-server). This logger captures the following information, all of which is visible in the ClearML web UI:
 
-- The full spaCy config file contents
+- The full spaCy config file contents.
 - Code information such as git repository, commit ID and uncommitted changes.
-- Full console output
-- Miscellaneous info such as time, python version and hardware information
+- Full console output.
+- Miscellaneous info such as time, python version and hardware information.
 - Output scalars:
     - The final score is logged under the scalar `score`.
-    - Individual component scores are grouped together on one scalar plot, use the web UI to filter.
+    - Individual component scores are grouped together on one scalar plot (filterable using the web UI).
     - Loss values of different components are logged with the `loss_` prefix.
 
-Then optionally, depending on the setting below, the following can be captured:
+In addition to the above, the following artifacts can also be optionally captured:
 
-- Best model directory (zipped)
-- Latest model directory (zipped)
-- Dataset used to train (will be versioned using ClearML Data and linked to under Configuration -> User Properties)
+- Best model directory (zipped).
+- Latest model directory (zipped).
+- Dataset used to train.
+	- Versioned using ClearML Data and linked to under Configuration -> User Properties on the web UI.
 
 
 **Note** that by default, the full (interpolated)
 [training config](https://spacy.io/usage/training#config) is sent over to 
-MLflow. If you prefer to **exclude certain information** such as path
+ClearML. If you prefer to **exclude certain information** such as path
 names, you can list those fields in "dot notation" in the
 `remove_config_values` parameter. These fields will then be removed from the
 config before uploading, but will otherwise remain in the config file stored

--- a/README.md
+++ b/README.md
@@ -158,15 +158,15 @@ clearml-init
 using the [ClearML](https://www.clear.ml/) tool. To use
 this logger, ClearML should be installed and you should have initialized (using the command above).
 The logger will send all the gathered information to your ClearML server, either [the hosted free tier](https://app.clear.ml) 
-or the open source [self-hosted server](https://github.com/allegroai/clearml-server). This logger captures all the following information (all visible in the webUI):
+or the open source [self-hosted server](https://github.com/allegroai/clearml-server). This logger captures all the following information (all visible in the web UI):
 
 - The full spaCy config file contents
 - Code information such as git repository, commit ID and uncommitted changes.
 - Full console output
-- Miscellanious info such as time, python version and hardware information
+- Miscellaneous info such as time, python version and hardware information
 - Output scalars:
     - The final score is logged under the scalar `score`.
-    - Individual component scores are grouped together on 1 scalar plot, use the webUI to filter.
+    - Individual component scores are grouped together on one scalar plot, use the web UI to filter.
     - Loss values of different components are logged with the `loss_` prefix.
 
 Then optionally, depending on the setting below, the following can be captured:

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ clearml-init
 ### Usage
 
 `spacy.ClearMLLogger.v1` is a logger that tracks the results of each training step
-using the [ClearML](https://www.mlflow.org/) tool. To use
+using the [ClearML](https://www.clear.ml/) tool. To use
 this logger, ClearML should be installed and you should have initialized (using the command above).
 The logger will send all the gathered information to your ClearML server, either [the hosted free tier](https://app.clear.ml) 
 or the open source [self-hosted server](https://github.com/allegroai/clearml-server). This logger captures all the following information (all visible in the webUI):

--- a/README.md
+++ b/README.md
@@ -157,16 +157,16 @@ clearml-init
 `spacy.ClearMLLogger.v1` is a logger that tracks the results of each training step
 using the [ClearML](https://www.mlflow.org/) tool. To use
 this logger, ClearML should be installed and you should have initialized (using the command above).
-The logger will send all the gathered information to your ClearML server, either [the hosted free tier](https://github.com/allegroai/clearml-server) 
+The logger will send all the gathered information to your ClearML server, either [the hosted free tier](https://app.clear.ml) 
 or the open source [self-hosted server](https://github.com/allegroai/clearml-server). This logger captures all the following information (all visible in the webUI):
 
-- The full SpaCy config file contents
+- The full spaCy config file contents
 - Code information such as git repository, commit ID and uncommitted changes.
 - Full console output
 - Miscellanious info such as time, python version and hardware information
-- Output metrics:
-    - The final score is logged under the metric `score`.
-    - Individual component scores are grouped together on 1 plot, use the webUI to filter.
+- Output scalars:
+    - The final score is logged under the scalar `score`.
+    - Individual component scores are grouped together on 1 scalar plot, use the webUI to filter.
     - Loss values of different components are logged with the `loss_` prefix.
 
 Then optionally, depending on the setting below, the following can be captured:
@@ -188,19 +188,21 @@ on your local system.
 
 ```ini
 [training.logger]
-@loggers = "spacy.MLflowLogger.v1"
-experiment_id = "1"
-run_name = "with_fast_alignments"
-nested = False
+@loggers = "spacy.ClearMLLogger.v1"
+project_name = "Hello ClearML!"
+model_log_interval = 1000
+log_best_dir = training/model-best
+log_latest_dir = training/model-last
+log_dataset_dir = corpus
 remove_config_values = ["paths.train", "paths.dev", "corpora.train.path", "corpora.dev.path"]
 ```
 
 | Name                   | Type            | Description                                                                                                                                                                                                                     |
 | ---------------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `project_name`         | `str`           | The name of the project in the ClearML interface. The project will be created automatically if it doesn't exist yet.                                                                                                            |
-| `remove_config_values` | `List[str]`     | A list of values to exclude from the config before it is uploaded to ClearML (default: `[]`).                                                                                                                                       |
-| `model_log_interval`   | `Optional[int]` | Steps to wait between logging model checkpoints to the ClearML dasboard (default: `None`). Will have no effect without also setting `log_best_dir` or log_latest_dir`.                                                          |
-| `log_dataset_dir`      | `Optional[str]` | Directory containing the dataset to be logged and versioned as a ClearML Dataset (default: `None`).                                                                                                                             |
 | `task_name`            | `Optional[str]` | The name of the ClearML task. A task is an experiment that lives inside a project. Can be non-unique. (default: `spaCy Training`).                                                                                              |
-| `log_best_dir`         | `Optional[str]` | Directory containing the best trained model as saved by spaCy (by default in `training/model-best`), to be logged and versioned as a ClearML artifact (default: `None`)                                                             |
-| `log_latest_dir`       | `Optional[str]` | Directory containing the latest trained model as saved by spaCy (by default in `training/model-last`), to be logged and versioned as a ClearML artifact (default: `None`)                                                           |
+| `remove_config_values` | `List[str]`     | A list of values to exclude from the config before it is uploaded to ClearML (default: `[]`).                                                                                                                                   |
+| `model_log_interval`   | `Optional[int]` | Steps to wait between logging model checkpoints to the ClearML dasboard (default: `None`). Will have no effect without also setting `log_best_dir` or `log_latest_dir`.                                                         |
+| `log_best_dir`         | `Optional[str]` | Directory containing the best trained model as saved by spaCy (by default in `training/model-best`), to be logged and versioned as a ClearML artifact (default: `None`)                                                         |
+| `log_latest_dir`       | `Optional[str]` | Directory containing the latest trained model as saved by spaCy (by default in `training/model-last`), to be logged and versioned as a ClearML artifact (default: `None`)                                                       |
+| `log_dataset_dir`      | `Optional[str]` | Directory containing the dataset to be logged and versioned as a [ClearML Dataset](https://clear.ml/docs/latest/docs/clearml_data/clearml_data/) (default: `None`).                                                             |

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ spacy_loggers =
     spacy.WandbLogger.v2 = spacy_loggers.wandb:wandb_logger_v2
     spacy.WandbLogger.v1 = spacy_loggers.wandb:wandb_logger_v1
     spacy.MLflowLogger.v1 = spacy_loggers.mlflow:mlflow_logger_v1
+    spacy.ClearMLLogger.v1 = spacy_loggers.clearml:clearml_logger_v1
 
 [flake8]
 ignore = E203, E266, E501, E731, W503, E741

--- a/spacy_loggers/clearml.py
+++ b/spacy_loggers/clearml.py
@@ -5,6 +5,7 @@ import sys
 from spacy import util
 from spacy.training.loggers import console_logger
 
+
 # entry point: spacy.ClearMLLogger.v1
 def clearml_logger_v1(
     project_name: str,
@@ -20,7 +21,7 @@ def clearml_logger_v1(
         from clearml import Task, Dataset, OutputModel  # noqa: F401
     except ImportError as exc:
         raise ImportError(
-            "The 'mlflow' library could not be found - did you install it? "
+            "The 'clearml' library could not be found - did you install it? "
             "Alternatively, specify the 'ConsoleLogger' in the "
             "'training.logger' config section, instead of the 'MLflowLogger'."
         ) from exc
@@ -114,7 +115,6 @@ def clearml_logger_v1(
                             )
 
         def finalize() -> None:
-
             console_finalize()
             task.flush(wait_for_uploads=True)
             task.close()

--- a/spacy_loggers/clearml.py
+++ b/spacy_loggers/clearml.py
@@ -9,10 +9,10 @@ from spacy.training.loggers import console_logger
 # entry point: spacy.ClearMLLogger.v1
 def clearml_logger_v1(
     project_name: str,
+    task_name: str,
     remove_config_values: List[str] = [],
     model_log_interval: Optional[int] = None,
     log_dataset_dir: Optional[str] = None,
-    task_name: Optional[str] = None,
     log_best_dir: Optional[str] = None,
     log_latest_dir: Optional[str] = None,
 ):
@@ -38,7 +38,7 @@ def clearml_logger_v1(
         config = util.dot_to_dict(config_dot)
         task = Task.init(
             project_name=project_name,
-            task_name=task_name if task_name else "spaCy Training",
+            task_name=task_name,
             output_uri=True,
         )
         for config_section, subconfig_or_value in config.items():
@@ -69,12 +69,13 @@ def clearml_logger_v1(
         def log_step(info: Optional[Dict[str, Any]]):
             console_log_step(info)
             if info is not None:
-                score = info["score"]
-                other_scores = info["other_scores"]
-                losses = info["losses"]
-                task.get_logger().report_scalar(
-                    "Score", "Score", iteration=info["step"], value=score
-                )
+                score = info.get("score")
+                other_scores = info.get("other_scores")
+                losses = info.get("losses")
+                if score:
+                    task.get_logger().report_scalar(
+                        "Score", "Score", iteration=info["step"], value=score
+                    )
                 if losses:
                     for metric, metric_value in losses.items():
                         task.get_logger().report_scalar(

--- a/spacy_loggers/clearml.py
+++ b/spacy_loggers/clearml.py
@@ -62,7 +62,7 @@ def clearml_logger_v1(
             task.set_user_properties(
                 {
                     "name": "Created Dataset ID",
-                    "value": f'<a href="{dataset._task.get_output_log_web_page()}">{dataset.id}</a>',
+                    "value": dataset.id,
                 }
             )
 

--- a/spacy_loggers/clearml.py
+++ b/spacy_loggers/clearml.py
@@ -1,0 +1,124 @@
+import os
+from typing import Dict, Any, Tuple, Callable, List, Optional, IO
+import sys
+
+from spacy import util
+from spacy.training.loggers import console_logger
+
+# entry point: spacy.ClearMLLogger.v1
+def clearml_logger_v1(
+    project_name: str,
+    remove_config_values: List[str] = [],
+    model_log_interval: Optional[int] = None,
+    log_dataset_dir: Optional[str] = None,
+    task_name: Optional[str] = None,
+    log_best_dir: Optional[str] = None,
+    log_latest_dir: Optional[str] = None,
+):
+    try:
+        # test that these are available
+        from clearml import Task, Dataset, OutputModel  # noqa: F401
+    except ImportError as exc:
+        raise ImportError(
+            "The 'mlflow' library could not be found - did you install it? "
+            "Alternatively, specify the 'ConsoleLogger' in the "
+            "'training.logger' config section, instead of the 'MLflowLogger'."
+        ) from exc
+
+    console = console_logger(progress_bar=False)
+
+    def setup_logger(
+        nlp: "Language", stdout: IO = sys.stdout, stderr: IO = sys.stderr
+    ) -> Tuple[Callable[[Dict[str, Any]], None], Callable[[], None]]:
+        config = nlp.config.interpolate()
+        config_dot = util.dict_to_dot(config)
+        for field in remove_config_values:
+            del config_dot[field]
+        config = util.dot_to_dict(config_dot)
+        task = Task.init(
+            project_name=project_name,
+            task_name=task_name if task_name else "spaCy Training",
+            output_uri=True
+        )
+        for config_section, subconfig_or_value in config.items():
+            task.connect(subconfig_or_value, name=config_section)
+
+        # Connect 2 models to the task, we will periodically update their weights later on
+        if log_best_dir:
+            best_model = OutputModel(task=task, framework="spaCy", name='Best Model')
+        if log_latest_dir:
+            last_model = OutputModel(task=task, framework="spaCy", name='Last Model')
+
+        console_log_step, console_finalize = console(nlp, stdout, stderr)
+
+        if log_dataset_dir:
+            dataset = Dataset.create(
+                dataset_project=project_name,
+                dataset_name=os.path.basename(log_dataset_dir)
+            )
+            dataset.add_files(log_dataset_dir)
+            dataset.finalize(auto_upload=True)
+            task.set_user_properties({
+                "name": "Created Dataset ID",
+                "value": f'<a href="{dataset._task.get_output_log_web_page()}">{dataset.id}</a>'
+            })
+
+        def log_step(info: Optional[Dict[str, Any]]):
+            console_log_step(info)
+            if info is not None:
+                score = info["score"]
+                other_scores = info["other_scores"]
+                losses = info["losses"]
+                task.get_logger().report_scalar("Score", "Score", iteration=info["step"], value=score)
+                if losses:
+                    for metric, metric_value in losses.items():
+                        task.get_logger().report_scalar(
+                            title=f"loss_{metric}",
+                            series=f"loss_{metric}",
+                            iteration=info["step"],
+                            value=metric_value
+                        )
+                if isinstance(other_scores, dict):
+                    # other_scores is usually a nested dict, so group they by the first key and flatten the rest
+                    # combine flattened submetrics on the same ClearML graph when they have the same first key
+                    for metric, metric_value in other_scores.items():
+                        if isinstance(metric_value, dict):
+                            sub_metrics_dict = util.dict_to_dot(metric_value)
+                            for sub_metric, sub_metric_value in sub_metrics_dict.items():
+                                # Scalars with the same title get plotted on the same graph as multiple traces
+                                # This saves a lot of space in the UI
+                                task.get_logger().report_scalar(
+                                    title=metric,
+                                    series=sub_metric,
+                                    iteration=info["step"],
+                                    value=sub_metric_value
+                                )
+                        elif isinstance(metric_value, (float, int)):
+                            task.get_logger().report_scalar(metric, metric, iteration=info["step"], value=metric_value)
+                if model_log_interval and info.get("output_path"):
+                    if (
+                        info["step"] % model_log_interval == 0
+                        and info["step"] != 0
+                    ):
+                        if log_latest_dir:
+                            last_model.update_weights_package(
+                                weights_path=log_latest_dir,
+                                auto_delete_file=False,
+                                target_filename='last_model'
+                            )
+                        if log_best_dir and info["score"] == max(info["checkpoints"])[0]:
+                            best_model.update_weights_package(
+                                weights_path=log_best_dir,
+                                auto_delete_file=False,
+                                target_filename='best_model'
+                            )
+
+        def finalize() -> None:
+
+            console_finalize()
+            task.flush(wait_for_uploads=True)
+            task.close()
+
+        return log_step, finalize
+
+    return setup_logger

--- a/spacy_loggers/clearml.py
+++ b/spacy_loggers/clearml.py
@@ -23,7 +23,7 @@ def clearml_logger_v1(
         raise ImportError(
             "The 'clearml' library could not be found - did you install it? "
             "Alternatively, specify the 'ConsoleLogger' in the "
-            "'training.logger' config section, instead of the 'MLflowLogger'."
+            "'training.logger' config section, instead of the 'ClearMLLogger'."
         ) from exc
 
     console = console_logger(progress_bar=False)

--- a/spacy_loggers/tests/test_registry.py
+++ b/spacy_loggers/tests/test_registry.py
@@ -7,7 +7,7 @@ FUNCTIONS = [
     ("loggers", "spacy.WandbLogger.v3"),
     ("loggers", "spacy.WandbLogger.v4"),
     ("loggers", "spacy.MLflowLogger.v1"),
-    ("loggers", "spacy.ClearMLLogger.v1")
+    ("loggers", "spacy.ClearMLLogger.v1"),
 ]
 
 

--- a/spacy_loggers/tests/test_registry.py
+++ b/spacy_loggers/tests/test_registry.py
@@ -7,6 +7,7 @@ FUNCTIONS = [
     ("loggers", "spacy.WandbLogger.v3"),
     ("loggers", "spacy.WandbLogger.v4"),
     ("loggers", "spacy.MLflowLogger.v1"),
+    ("loggers", "spacy.ClearMLLogger.v1")
 ]
 
 


### PR DESCRIPTION
Thanks a lot for all the great work you all do :)

This PR is to add a logger for [ClearML](https://github.com/allegroai/clearml).

## Some open questions:

### The PR is only tested on [this sample](https://github.com/explosion/projects/tree/v3/pipelines/tagger_parser_ud) project so far. 
I'm a spaCy newbie, so not sure if I should do more testing :)  I got the tip to clone and adapt [this project](https://github.com/explosion/projects/tree/v3/integrations/wandb) which I'll try to do if I can get the time for it.

### Metrics visualisation
Currently, I've grouped all metrics that are more than 1 layer deep on the same graph in the webUI. The reason being that giving every one of them their own separate graph, makes the UI very full of graphs. Now, there are 2 graphs that are chock-full of metrics, but they do belong near each other and it's easy to filter them within the graph itself. Personally, I think this makes sense, but I'm all for changing it like it is in the other loggers if you prefer it that way :)

Here is a gif of what the result looks like:
![graphs_spacy](https://user-images.githubusercontent.com/11781950/194252554-dbec0582-d1e8-4138-aef4-6a491112a47f.gif)
