### PR TITLE
mlflow_logger_v1 - Adding option to log last model

### DIFF
--- a/spacy_loggers/mlflow.py
+++ b/spacy_loggers/mlflow.py
@@ -9,8 +9,20 @@ from spacy import util
 from spacy import Language
 from spacy import load
 from spacy.training.loggers import console_logger
+from pathlib import Path
+from loguru import logger
+# logger.remove()
+# logger.add('file.log', filter=__name__, level='DEBUG')
 
 
+class ModelDir:
+    def __init__(self) -> None:
+        self.path = None
+
+    def update(self, path: str) -> None:
+        self.path = path
+        
+@logger.catch
 # entry point: spacy.MLflowLogger.v1
 def mlflow_logger_v1(
     run_id: Optional[str] = None,
@@ -19,6 +31,7 @@ def mlflow_logger_v1(
     nested: bool = False,
     tags: Optional[Dict[str, Any]] = None,
     remove_config_values: List[str] = [],
+    log_latest_dir: bool = True,
 ):
     try:
         import mlflow
@@ -33,7 +46,7 @@ def mlflow_logger_v1(
         )
 
     console = console_logger(progress_bar=False)
-
+    
     def setup_logger(
         nlp: "Language", stdout: IO = sys.stdout, stderr: IO = sys.stderr
     ) -> Tuple[Callable[[Dict[str, Any]], None], Callable[[], None]]:
@@ -58,6 +71,26 @@ def mlflow_logger_v1(
             mlflow.log_params({k.replace("@", ""): v for k, v in batch})
 
         console_log_step, console_finalize = console(nlp, stdout, stderr)
+        
+        if log_latest_dir:
+            latest_model = ModelDir()
+            
+        def log_model(path, name):
+            logger.debug(f'logging model: {path}')
+            mlflow.log_artifacts(
+                path, 
+                name
+            )
+            logger.debug('model artifact uploaded')
+            # Can't use below as the mlflow.spacy.log_model method seems to abort abruptly
+            # Only seems to work if it is called from within log_step but we prob don't want
+            # To force an upload every step. I don't understand this behaviour
+            # Safer to just use log_artifacts to upload the whole folder
+            # mlflow.spacy.log_model(
+            #     load(path),
+            #     'model_last_spacy'
+            # )
+            # logger.debug(f'model spacy model logged')
 
         def log_step(info: Optional[Dict[str, Any]]):
             console_log_step(info)
@@ -66,23 +99,37 @@ def mlflow_logger_v1(
                 other_scores = info["other_scores"]
                 losses = info["losses"]
                 output_path = info.get("output_path", None)
+                if log_latest_dir:
+                    latest_model.update(output_path)
+                
                 if score is not None:
-                    mlflow.log_metric("score", score)
+                    mlflow.log_metric("score", score, info["step"])
                 if losses:
-                    mlflow.log_metrics({f"loss_{k}": v for k, v in losses.items()})
+                    mlflow.log_metrics({f"loss_{k}": v for k, v in losses.items()}, info["step"])
                 if isinstance(other_scores, dict):
                     mlflow.log_metrics(
                         {
                             k: v
                             for k, v in util.dict_to_dot(other_scores).items()
                             if isinstance(v, float) or isinstance(v, int)
-                        }
+                        },
+                        info["step"]
                     )
                 if output_path and score == max(info["checkpoints"])[0]:
                     nlp = load(output_path)
                     mlflow.spacy.log_model(nlp, "best")
+                    logger.debug(f'Uploading "model_best" artifact from {output_path}')
+                    log_model(output_path, 'model_best')
+                    
 
         def finalize() -> None:
+
+            if log_latest_dir:
+                logger.debug(f'Uploading "model_last" artifact from {latest_model.path}')
+                log_model(latest_model.path, 'model_last')
+                logger.debug('Uploaded model_last')
+                
+            print('End run')
             console_finalize()
             mlflow.end_run()
 


### PR DESCRIPTION
I noticed the mlflow logger only seems to log the "best" model.  This is a bit confusing as the metrics summary mlflow displays, gives the results for the "last" model.

Anyway the wandb logger and the clearml logger both look like they include some functionaliity to choose which model folder to track (or both).  So I added functionality to log the "last" model with a boolean option in the `[training.logger]` config.  I thought Id stick to a similar pattern as the one implemented in the wandb logger (which handles this aspect neatly).

**Note:** I ended up using `mlflow.log_artifact()` rather than `mlflow.spacy.log_model()` because when I use the latter method outside of the `log_step()` function it looks like spacy just aborts the process abruptly, without letting the mlflow.spacy function do its thing.  It works if I put it in the log_step() function but I wanted to just trigger an upload at the end... otherwise we'd seriously slow down the training process by forcing a model upload every training step.  Perhaps I could use some feedback on this part

Separately, I also added the "step" value to each `mlflow.log_metrics()` call as this just makes the mlflow plot visualisations a bit nicer if you want to view it by step rather than by time on the x axis.