### PR TITLE
Remove unused wasabi requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,3 @@
-# Install requirements (also in setup.cfg)
-wasabi>=0.8.1,<1.1.0
-
 # Testing/development requirements
 spacy>=3.0.0
 pytest>=5.0.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,8 +12,6 @@ long_description_content_type = text/markdown
 zip_safe = true
 include_package_data = true
 python_requires = >=3.6
-install_requires =
-    wasabi>=0.8.1,<1.1.0
 
 [options.entry_points]
 spacy_loggers =


### PR DESCRIPTION
The wasabi requirement appears to be an unintentional holdover from an early development version.