### PR TITLE
Add `ChainLogger`, `PyTorchLogger` and `LookupLogger`

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,8 +274,8 @@ logger2 = {"@loggers": "spacy.ConsoleLogger.v1", "progress_bar": "true"}
 
 | Name       | Type                 | Description                                        |
 | ---------- | -------------------- | -------------------------------------------------- |
-| `logger1`  | `Callable`           | The first logger in the chain.                     |
-| `logger2`  | `Callable`           | The second logger in the chain.                    |
+| `logger1`  | `Optional[Callable]` | The first logger in the chain (default: `None`).   |
+| `logger2`  | `Optional[Callable]` | The second logger in the chain (default: `None`).  |
 | `logger3`  | `Optional[Callable]` | The third logger in the chain (default: `None`).   |
 | `logger4`  | `Optional[Callable]` | The fourth logger in the chain (default: `None`).  |
 | `logger5`  | `Optional[Callable]` | The fifth logger in the chain (default: `None`).   |

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ logger2 = {"@loggers": "spacy.LookupLogger.v1", "substring": "pytorch"}
 This logger can be used to daisy-chain multiple loggers and execute them in-order. Loggers that are executed earlier in the chain
 can pass information to those that come later by adding it to the dictionary that is passed to them.
 
-Currently, upto 10 loggers can be chained together.
+Currently, up to 10 loggers can be chained together.
 
 ### Example config
 
@@ -289,7 +289,7 @@ logger2 = {"@loggers": "spacy.ConsoleLogger.v1", "progress_bar": "true"}
 
 ### Usage
 
-This logger can be used lookup statistics in the info dictionary and print them to `stdout`. It is primarily
+This logger can be used to lookup statistics in the info dictionary and print them to `stdout`. It is primarily
 intended to be used as a tool when developing new loggers.
 
 ### Example config

--- a/README.md
+++ b/README.md
@@ -241,8 +241,8 @@ The following PyTorch statistics are currently supported:
 ```ini
 [training.logger]
 @loggers = "spacy.ChainLogger.v1"
-first = {"@loggers": "spacy.PyTorchLogger.v1", "prefix": "pytorch", "device": "0", "cuda_mem_metric": "current"}
-second = {"@loggers": "spacy.LookupLogger.v1", "substring": "pytorch"}
+logger1 = {"@loggers": "spacy.PyTorchLogger.v1", "prefix": "pytorch", "device": "0", "cuda_mem_metric": "current"}
+logger2 = {"@loggers": "spacy.LookupLogger.v1", "substring": "pytorch"}
 ```
 
 | Name              | Type  | Description                                                                                                                                                     |
@@ -268,22 +268,22 @@ Currently, upto 10 loggers can be chained together.
 ```ini
 [training.logger]
 @loggers = "spacy.ChainLogger.v1"
-first = {"@loggers": "spacy.PyTorchLogger.v1"}
-second = {"@loggers": "spacy.ConsoleLogger.v1", "progress_bar": "true"}
+logger1 = {"@loggers": "spacy.PyTorchLogger.v1"}
+logger2 = {"@loggers": "spacy.ConsoleLogger.v1", "progress_bar": "true"}
 ```
 
-| Name      | Type                 | Description                                        |
-| --------- | -------------------- | -------------------------------------------------- |
-| `first`   | `Callable`           | The first logger in the chain.                     |
-| `second`  | `Callable`           | The second logger in the chain.                    |
-| `third`   | `Optional[Callable]` | The third logger in the chain (default: `None`).   |
-| `fourth`  | `Optional[Callable]` | The fourth logger in the chain (default: `None`).  |
-| `fifth`   | `Optional[Callable]` | The fifth logger in the chain (default: `None`).   |
-| `sixth`   | `Optional[Callable]` | The sixth logger in the chain (default: `None`).   |
-| `seventh` | `Optional[Callable]` | The seventh logger in the chain (default: `None`). |
-| `eighth`  | `Optional[Callable]` | The eighth logger in the chain (default: `None`).  |
-| `ninth`   | `Optional[Callable]` | The ninth logger in the chain (default: `None`).   |
-| `tenth`   | `Optional[Callable]` | The tenth logger in the chain (default: `None`).   |
+| Name       | Type                 | Description                                        |
+| ---------- | -------------------- | -------------------------------------------------- |
+| `logger1`  | `Callable`           | The first logger in the chain.                     |
+| `logger2`  | `Callable`           | The second logger in the chain.                    |
+| `logger3`  | `Optional[Callable]` | The third logger in the chain (default: `None`).   |
+| `logger4`  | `Optional[Callable]` | The fourth logger in the chain (default: `None`).  |
+| `logger5`  | `Optional[Callable]` | The fifth logger in the chain (default: `None`).   |
+| `logger6`  | `Optional[Callable]` | The sixth logger in the chain (default: `None`).   |
+| `logger7`  | `Optional[Callable]` | The seventh logger in the chain (default: `None`). |
+| `logger8`  | `Optional[Callable]` | The eighth logger in the chain (default: `None`).  |
+| `logger9`  | `Optional[Callable]` | The ninth logger in the chain (default: `None`).   |
+| `logger10` | `Optional[Callable]` | The tenth logger in the chain (default: `None`).   |
 
 ## LookupLogger
 
@@ -297,8 +297,8 @@ intended to be used as a tool when developing new loggers.
 ```ini
 [training.logger]
 @loggers = "spacy.ChainLogger.v1"
-first = {"@loggers": "spacy.PyTorchLogger.v1", "prefix": "pytorch"}
-second = {"@loggers": "spacy.LookupLogger.v1", "substring": "pytorch"}
+logger1 = {"@loggers": "spacy.PyTorchLogger.v1", "prefix": "pytorch"}
+logger2 = {"@loggers": "spacy.LookupLogger.v1", "substring": "pytorch"}
 ```
 
 | Name        | Type  | Description                                                               |

--- a/README.md
+++ b/README.md
@@ -298,9 +298,9 @@ intended to be used as a tool when developing new loggers.
 [training.logger]
 @loggers = "spacy.ChainLogger.v1"
 logger1 = {"@loggers": "spacy.PyTorchLogger.v1", "prefix": "pytorch"}
-logger2 = {"@loggers": "spacy.LookupLogger.v1", "substring": "pytorch"}
+logger2 = {"@loggers": "spacy.LookupLogger.v1", "patterns": ["^(p|P)ytorch"]}
 ```
 
-| Name        | Type  | Description                                                               |
-| ----------- | ----- | ------------------------------------------------------------------------- |
-| `substring` | `str` | If a statistic's name contains this string, it's printed out to `stdout`. |
+| Name       | Type        | Description                                                                                          |
+| ---------- | ----------- | ---------------------------------------------------------------------------------------------------- |
+| `patterns` | `List[str]` | A list of regular expressions. If a statistic's name matches one of these, it's printed to `stdout`. |

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ library.
 - [Weights & Biases](https://www.wandb.com)
 - [MLflow](https://www.mlflow.org/)
 - [ClearML](https://www.clear.ml/)
+- [PyTorch](https://pytorch.org/)
+
+`spacy-loggers` also provides additional utility loggers to facilitate interoperation
+between individual loggers.
 
 If you'd like to add a new logger or logging option, please submit a PR to this
 repo!
@@ -114,7 +118,7 @@ the following actions are performed:
 By default, the tracking API writes data into files in a local `./mlruns` directory.
 
 **Note** that by default, the full (interpolated)
-[training config](https://spacy.io/usage/training#config) is sent over to 
+[training config](https://spacy.io/usage/training#config) is sent over to
 MLflow. If you prefer to **exclude certain information** such as path
 names, you can list those fields in "dot notation" in the
 `remove_config_values` parameter. These fields will then be removed from the
@@ -157,7 +161,7 @@ clearml-init
 `spacy.ClearMLLogger.v1` is a logger that tracks the results of each training step
 using the [ClearML](https://www.clear.ml/) tool. To use
 this logger, ClearML should be installed and you should have initialized (using the command above).
-The logger will send all the gathered information to your ClearML server, either [the hosted free tier](https://app.clear.ml) 
+The logger will send all the gathered information to your ClearML server, either [the hosted free tier](https://app.clear.ml)
 or the open source [self-hosted server](https://github.com/allegroai/clearml-server). This logger captures the following information, all of which is visible in the ClearML web UI:
 
 - The full spaCy config file contents.
@@ -165,20 +169,19 @@ or the open source [self-hosted server](https://github.com/allegroai/clearml-ser
 - Full console output.
 - Miscellaneous info such as time, python version and hardware information.
 - Output scalars:
-    - The final score is logged under the scalar `score`.
-    - Individual component scores are grouped together on one scalar plot (filterable using the web UI).
-    - Loss values of different components are logged with the `loss_` prefix.
+  - The final score is logged under the scalar `score`.
+  - Individual component scores are grouped together on one scalar plot (filterable using the web UI).
+  - Loss values of different components are logged with the `loss_` prefix.
 
 In addition to the above, the following artifacts can also be optionally captured:
 
 - Best model directory (zipped).
 - Latest model directory (zipped).
 - Dataset used to train.
-	- Versioned using ClearML Data and linked to under Configuration -> User Properties on the web UI.
-
+  - Versioned using ClearML Data and linked to under Configuration -> User Properties on the web UI.
 
 **Note** that by default, the full (interpolated)
-[training config](https://spacy.io/usage/training#config) is sent over to 
+[training config](https://spacy.io/usage/training#config) is sent over to
 ClearML. If you prefer to **exclude certain information** such as path
 names, you can list those fields in "dot notation" in the
 `remove_config_values` parameter. These fields will then be removed from the
@@ -199,12 +202,105 @@ log_dataset_dir = corpus
 remove_config_values = ["paths.train", "paths.dev", "corpora.train.path", "corpora.dev.path"]
 ```
 
-| Name                   | Type            | Description                                                                                                                                                                                                                     |
-| ---------------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `project_name`         | `str`           | The name of the project in the ClearML interface. The project will be created automatically if it doesn't exist yet.                                                                                                            |
-| `task_name`            | `str`           | The name of the ClearML task. A task is an experiment that lives inside a project. Can be non-unique.                                                                                                                           |
-| `remove_config_values` | `List[str]`     | A list of values to exclude from the config before it is uploaded to ClearML (default: `[]`).                                                                                                                                   |
-| `model_log_interval`   | `Optional[int]` | Steps to wait between logging model checkpoints to the ClearML dasboard (default: `None`). Will have no effect without also setting `log_best_dir` or `log_latest_dir`.                                                         |
-| `log_best_dir`         | `Optional[str]` | Directory containing the best trained model as saved by spaCy (by default in `training/model-best`), to be logged and versioned as a ClearML artifact (default: `None`)                                                         |
-| `log_latest_dir`       | `Optional[str]` | Directory containing the latest trained model as saved by spaCy (by default in `training/model-last`), to be logged and versioned as a ClearML artifact (default: `None`)                                                       |
-| `log_dataset_dir`      | `Optional[str]` | Directory containing the dataset to be logged and versioned as a [ClearML Dataset](https://clear.ml/docs/latest/docs/clearml_data/clearml_data/) (default: `None`).                                                             |
+| Name                   | Type            | Description                                                                                                                                                               |
+| ---------------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `project_name`         | `str`           | The name of the project in the ClearML interface. The project will be created automatically if it doesn't exist yet.                                                      |
+| `task_name`            | `str`           | The name of the ClearML task. A task is an experiment that lives inside a project. Can be non-unique.                                                                     |
+| `remove_config_values` | `List[str]`     | A list of values to exclude from the config before it is uploaded to ClearML (default: `[]`).                                                                             |
+| `model_log_interval`   | `Optional[int]` | Steps to wait between logging model checkpoints to the ClearML dasboard (default: `None`). Will have no effect without also setting `log_best_dir` or `log_latest_dir`.   |
+| `log_best_dir`         | `Optional[str]` | Directory containing the best trained model as saved by spaCy (by default in `training/model-best`), to be logged and versioned as a ClearML artifact (default: `None`)   |
+| `log_latest_dir`       | `Optional[str]` | Directory containing the latest trained model as saved by spaCy (by default in `training/model-last`), to be logged and versioned as a ClearML artifact (default: `None`) |
+| `log_dataset_dir`      | `Optional[str]` | Directory containing the dataset to be logged and versioned as a [ClearML Dataset](https://clear.ml/docs/latest/docs/clearml_data/clearml_data/) (default: `None`).       |
+
+## PyTorchLogger
+
+### Installation
+
+This logger requires `torch` to be installed:
+
+```bash
+pip install torch
+```
+
+### Usage
+
+`spacy.PyTorchLogger.v1` is different from the other loggers above in that it does not act as a bridge between spaCy and
+an external framework. Instead, it is used to query PyTorch-specific metrics and make them available to other loggers.
+Therefore, it's primarily intended to be used with [ChainLogger](#chainlogger).
+
+Whenever a logging checkpoint is reached, it queries statistics from the PyTorch backend and stores them in
+the dictionary passed to it. Downstream loggers can thereafter lookup the statistics and log them to their
+preferred framework.
+
+The following PyTorch statistics are currently supported:
+
+- [CUDA memory statistics](https://pytorch.org/docs/stable/generated/torch.cuda.memory_stats.html#torch.cuda.memory_stats)
+
+### Example config
+
+```ini
+[training.logger]
+@loggers = "spacy.ChainLogger.v1"
+first = {"@loggers": "spacy.PyTorchLogger.v1", "prefix": "pytorch", "device": "0", "cuda_mem_metric": "current"}
+second = {"@loggers": "spacy.LookupLogger.v1", "substring": "pytorch"}
+```
+
+| Name              | Type  | Description                                                                                                                                                     |
+| ----------------- | ----- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `prefix`          | `str` | All metric names are prefixed with this string using dot notation, e.g: `<prefix>.<metric>` (default: `pytorch`).                                               |
+| `device`          | `int` | The identifier of the CUDA device (default: `0`).                                                                                                               |
+| `cuda_mem_pool`   | `str` | One of the memory pool values specified in the PyTorch docs: `all`, `large_pool`, `small_pool` (default: `all`).                                                |
+| `cuda_mem_metric` | `str` | One of the memory metric values specified in the PyTorch docs: `current`, `peak`, `allocated`, `freed`. To log all metrics, use `all` instead (default: `all`). |
+
+# Utility Loggers
+
+## ChainLogger
+
+### Usage
+
+This logger can be used to daisy-chain multiple loggers and execute them in-order. Loggers that are executed earlier in the chain
+can pass information to those that come later by adding it to the dictionary that is passed to them.
+
+Currently, upto 10 loggers can be chained together.
+
+### Example config
+
+```ini
+[training.logger]
+@loggers = "spacy.ChainLogger.v1"
+first = {"@loggers": "spacy.PyTorchLogger.v1"}
+second = {"@loggers": "spacy.ConsoleLogger.v1", "progress_bar": "true"}
+```
+
+| Name      | Type                 | Description                                        |
+| --------- | -------------------- | -------------------------------------------------- |
+| `first`   | `Callable`           | The first logger in the chain.                     |
+| `second`  | `Callable`           | The second logger in the chain.                    |
+| `third`   | `Optional[Callable]` | The third logger in the chain (default: `None`).   |
+| `fourth`  | `Optional[Callable]` | The fourth logger in the chain (default: `None`).  |
+| `fifth`   | `Optional[Callable]` | The fifth logger in the chain (default: `None`).   |
+| `sixth`   | `Optional[Callable]` | The sixth logger in the chain (default: `None`).   |
+| `seventh` | `Optional[Callable]` | The seventh logger in the chain (default: `None`). |
+| `eighth`  | `Optional[Callable]` | The eighth logger in the chain (default: `None`).  |
+| `ninth`   | `Optional[Callable]` | The ninth logger in the chain (default: `None`).   |
+| `tenth`   | `Optional[Callable]` | The tenth logger in the chain (default: `None`).   |
+
+## LookupLogger
+
+### Usage
+
+This logger can be used lookup statistics in the info dictionary and print them to `stdout`. It is primarily
+intended to be used as a tool when developing new loggers.
+
+### Example config
+
+```ini
+[training.logger]
+@loggers = "spacy.ChainLogger.v1"
+first = {"@loggers": "spacy.PyTorchLogger.v1", "prefix": "pytorch"}
+second = {"@loggers": "spacy.LookupLogger.v1", "substring": "pytorch"}
+```
+
+| Name        | Type  | Description                                                               |
+| ----------- | ----- | ------------------------------------------------------------------------- |
+| `substring` | `str` | If a statistic's name contains this string, it's printed out to `stdout`. |

--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ intended to be used as a tool when developing new loggers.
 [training.logger]
 @loggers = "spacy.ChainLogger.v1"
 logger1 = {"@loggers": "spacy.PyTorchLogger.v1", "prefix": "pytorch"}
-logger2 = {"@loggers": "spacy.LookupLogger.v1", "patterns": ["^(p|P)ytorch"]}
+logger2 = {"@loggers": "spacy.LookupLogger.v1", "patterns": ["^[pP]ytorch"]}
 ```
 
 | Name       | Type        | Description                                                                                          |

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,9 @@ spacy_loggers =
     spacy.WandbLogger.v1 = spacy_loggers.wandb:wandb_logger_v1
     spacy.MLflowLogger.v1 = spacy_loggers.mlflow:mlflow_logger_v1
     spacy.ClearMLLogger.v1 = spacy_loggers.clearml:clearml_logger_v1
+    spacy.ChainLogger.v1 = spacy_loggers.chain:chain_logger_v1
+    spacy.PyTorchLogger.v1 = spacy_loggers.pytorch:pytorch_logger_v1
+    spacy.LookupLogger.v1 = spacy_loggers.lookup:lookup_logger_v1
 
 [flake8]
 ignore = E203, E266, E501, E731, W503, E741

--- a/spacy_loggers/chain.py
+++ b/spacy_loggers/chain.py
@@ -9,8 +9,8 @@ from .util import LoggerT
 
 
 def chain_logger_v1(
-    logger1: LoggerT,
-    logger2: LoggerT,
+    logger1: Optional[LoggerT] = None,
+    logger2: Optional[LoggerT] = None,
     logger3: Optional[LoggerT] = None,
     logger4: Optional[LoggerT] = None,
     logger5: Optional[LoggerT] = None,
@@ -33,6 +33,8 @@ def chain_logger_v1(
             logger9,
             logger10,
         ]
+        if not any(loggers):
+            raise ValueError("No loggers passed to chain logger")
         callbacks = [
             setup(nlp, stdout, stderr) for setup in loggers if setup is not None
         ]

--- a/spacy_loggers/chain.py
+++ b/spacy_loggers/chain.py
@@ -1,0 +1,52 @@
+"""
+A utility logger that allows multiple loggers to be daisy-chained.
+"""
+from typing import Dict, Any, Optional, IO
+import sys
+
+from spacy import Language
+from .util import LoggerT
+
+
+def chain_logger_v1(
+    first: LoggerT,
+    second: LoggerT,
+    third: Optional[LoggerT] = None,
+    fourth: Optional[LoggerT] = None,
+    fifth: Optional[LoggerT] = None,
+    sixth: Optional[LoggerT] = None,
+    seventh: Optional[LoggerT] = None,
+    eighth: Optional[LoggerT] = None,
+    ninth: Optional[LoggerT] = None,
+    tenth: Optional[LoggerT] = None,
+) -> LoggerT:
+    def setup_logger(nlp: Language, stdout: IO = sys.stdout, stderr: IO = sys.stderr):
+        loggers = [
+            first,
+            second,
+            third,
+            fourth,
+            fifth,
+            sixth,
+            seventh,
+            eighth,
+            ninth,
+            tenth,
+        ]
+        callbacks = [
+            setup(nlp, stdout, stderr) for setup in loggers if setup is not None
+        ]
+
+        def log_step(info: Optional[Dict[str, Any]]):
+            nonlocal callbacks
+            for log_stepper, _ in callbacks:
+                log_stepper(info)
+
+        def finalize():
+            nonlocal callbacks
+            for _, finalizer in callbacks:
+                finalizer()
+
+        return log_step, finalize
+
+    return setup_logger

--- a/spacy_loggers/chain.py
+++ b/spacy_loggers/chain.py
@@ -9,29 +9,29 @@ from .util import LoggerT
 
 
 def chain_logger_v1(
-    first: LoggerT,
-    second: LoggerT,
-    third: Optional[LoggerT] = None,
-    fourth: Optional[LoggerT] = None,
-    fifth: Optional[LoggerT] = None,
-    sixth: Optional[LoggerT] = None,
-    seventh: Optional[LoggerT] = None,
-    eighth: Optional[LoggerT] = None,
-    ninth: Optional[LoggerT] = None,
-    tenth: Optional[LoggerT] = None,
+    logger1: LoggerT,
+    logger2: LoggerT,
+    logger3: Optional[LoggerT] = None,
+    logger4: Optional[LoggerT] = None,
+    logger5: Optional[LoggerT] = None,
+    logger6: Optional[LoggerT] = None,
+    logger7: Optional[LoggerT] = None,
+    logger8: Optional[LoggerT] = None,
+    logger9: Optional[LoggerT] = None,
+    logger10: Optional[LoggerT] = None,
 ) -> LoggerT:
     def setup_logger(nlp: Language, stdout: IO = sys.stdout, stderr: IO = sys.stderr):
         loggers = [
-            first,
-            second,
-            third,
-            fourth,
-            fifth,
-            sixth,
-            seventh,
-            eighth,
-            ninth,
-            tenth,
+            logger1,
+            logger2,
+            logger3,
+            logger4,
+            logger5,
+            logger6,
+            logger7,
+            logger8,
+            logger9,
+            logger10,
         ]
         callbacks = [
             setup(nlp, stdout, stderr) for setup in loggers if setup is not None

--- a/spacy_loggers/lookup.py
+++ b/spacy_loggers/lookup.py
@@ -1,0 +1,26 @@
+"""
+A utility logger that looks up specific statistics and prints them to stdout.
+"""
+from typing import Dict, Any, Optional, IO
+import sys
+
+from spacy import Language
+from .util import dict_to_dot, LoggerT
+
+
+def lookup_logger_v1(substring: str) -> LoggerT:
+    def setup_logger(nlp: Language, stdout: IO = sys.stdout, stderr: IO = sys.stderr):
+        def log_step(info: Optional[Dict[str, Any]]):
+            if info is None:
+                return
+            config_dot = dict_to_dot(info)
+            for k, v in config_dot.items():
+                if substring in k:
+                    stdout.writelines([k, " -> ", str(v), "\n"])
+
+        def finalize():
+            pass
+
+        return log_step, finalize
+
+    return setup_logger

--- a/spacy_loggers/lookup.py
+++ b/spacy_loggers/lookup.py
@@ -1,21 +1,25 @@
 """
 A utility logger that looks up specific statistics and prints them to stdout.
 """
-from typing import Dict, Any, Optional, IO
+from typing import Dict, Any, Optional, IO, List
 import sys
 
 from spacy import Language
-from .util import dict_to_dot, LoggerT
+from .util import dict_to_dot, LoggerT, setup_custom_stats_matcher
 
 
-def lookup_logger_v1(substring: str) -> LoggerT:
+def lookup_logger_v1(patterns: List[str]) -> LoggerT:
     def setup_logger(nlp: Language, stdout: IO = sys.stdout, stderr: IO = sys.stderr):
+        if len(patterns) == 0:
+            raise ValueError("Lookup logger has no patterns")
+        match_stat = setup_custom_stats_matcher(patterns)
+
         def log_step(info: Optional[Dict[str, Any]]):
             if info is None:
                 return
             config_dot = dict_to_dot(info)
             for k, v in config_dot.items():
-                if substring in k:
+                if match_stat(k):
                     stdout.writelines([k, " -> ", str(v), "\n"])
 
         def finalize():

--- a/spacy_loggers/lookup.py
+++ b/spacy_loggers/lookup.py
@@ -5,14 +5,14 @@ from typing import Dict, Any, Optional, IO, List
 import sys
 
 from spacy import Language
-from .util import dict_to_dot, LoggerT, setup_custom_stats_matcher
+from .util import dict_to_dot, LoggerT, matcher_for_regex_patterns
 
 
 def lookup_logger_v1(patterns: List[str]) -> LoggerT:
     def setup_logger(nlp: Language, stdout: IO = sys.stdout, stderr: IO = sys.stderr):
         if len(patterns) == 0:
-            raise ValueError("Lookup logger has no patterns")
-        match_stat = setup_custom_stats_matcher(patterns)
+            raise ValueError("Lookup logger should receive at least one pattern")
+        match_stat = matcher_for_regex_patterns(patterns)
 
         def log_step(info: Optional[Dict[str, Any]]):
             if info is None:

--- a/spacy_loggers/pytorch.py
+++ b/spacy_loggers/pytorch.py
@@ -1,0 +1,68 @@
+"""
+A logger that queries PyTorch metrics and passes that information to downstream loggers.
+"""
+from typing import Dict, Any, Optional, IO
+import sys
+
+from spacy import Language
+from .util import LoggerT
+
+
+def pytorch_logger_v1(
+    prefix: str = "pytorch",
+    device: int = 0,
+    cuda_mem_pool: str = "all",
+    cuda_mem_metric: str = "all",
+) -> LoggerT:
+    try:
+        import torch
+    except ImportError:
+        raise ImportError(
+            "The 'torch' library could not be found - did you install it? "
+            "Alternatively, specify the 'ConsoleLogger' in the "
+            "'training.logger' config section, instead of the 'PyTorchLogger'."
+        )
+
+    def setup_logger(nlp: Language, stdout: IO = sys.stdout, stderr: IO = sys.stderr):
+        expected_cuda_mem_pool = ("all", "large_pool", "small_pool")
+        expected_cuda_mem_metric = ("all", "current", "peak", "allocated", "free")
+
+        if cuda_mem_pool not in expected_cuda_mem_pool:
+            raise ValueError(
+                f"Got CUDA memory pool '{cuda_mem_pool}', but expected one of: '{expected_cuda_mem_pool}'"
+            )
+        elif cuda_mem_metric not in expected_cuda_mem_metric:
+            raise ValueError(
+                f"Got CUDA memory metric '{cuda_mem_metric}', but expected one of: '{expected_cuda_mem_metric}'"
+            )
+
+        def log_step(info: Optional[Dict[str, Any]]):
+            if info is None:
+                return
+
+            cuda_mem_stats = torch.cuda.memory_stats(device)
+            for stat, val in cuda_mem_stats.items():
+                splits = stat.split(".")
+                if len(splits) == 3:
+                    name, pool, metric = splits
+                    if pool != cuda_mem_pool:
+                        continue
+                    elif cuda_mem_metric != "all" and metric != cuda_mem_metric:
+                        continue
+                    info[f"{prefix}.{name}.{pool}.{metric}"] = val
+                elif len(splits) == 2:
+                    name, metric = splits
+                    if cuda_mem_metric != "all" and metric != cuda_mem_metric:
+                        continue
+                    info[f"{prefix}.{name}.{metric}"] = val
+                else:
+                    # Either global statistic or something that we haven't accounted for,
+                    # e.g: a newly added statistic. So, we'll just include it to be safe.
+                    info[f"{prefix}.{stat}"] = val
+
+        def finalize():
+            pass
+
+        return log_step, finalize
+
+    return setup_logger

--- a/spacy_loggers/tests/test_chain.py
+++ b/spacy_loggers/tests/test_chain.py
@@ -17,9 +17,8 @@ factory = "tok2vec"
 
 [training.logger]
 @loggers = "spacy.ChainLogger.v1"
-logger1 = {"@loggers": "spacy.PyTorchLogger.v1"}
-logger2 = {"@loggers": "spacy.ConsoleLogger.v1", "progress_bar": "true"}
-logger9 = {"@loggers": "spacy.ConsoleLogger.v1", "progress_bar": "true"}
+logger1 = {"@loggers": "spacy.ConsoleLogger.v1", "progress_bar": "true"}
+logger9 = {"@loggers": "spacy.LookupLogger.v1", patterns = ["test"]}
 """
 
 invalid_config_string = """

--- a/spacy_loggers/tests/test_chain.py
+++ b/spacy_loggers/tests/test_chain.py
@@ -40,8 +40,8 @@ factory = "tok2vec"
 
 def test_load_from_config():
     valid_logger, nlp = load_logger_from_config(valid_config_string)
-    _, _ = valid_logger(nlp)
+    valid_logger(nlp)
 
     with pytest.raises(ValueError, match="No loggers"):
         invalid_logger, nlp = load_logger_from_config(invalid_config_string)
-        _, _ = invalid_logger(nlp)
+        invalid_logger(nlp)

--- a/spacy_loggers/tests/test_chain.py
+++ b/spacy_loggers/tests/test_chain.py
@@ -18,7 +18,7 @@ factory = "tok2vec"
 [training.logger]
 @loggers = "spacy.ChainLogger.v1"
 logger1 = {"@loggers": "spacy.ConsoleLogger.v1", "progress_bar": "true"}
-logger9 = {"@loggers": "spacy.LookupLogger.v1", patterns = ["test"]}
+logger9 = {"@loggers": "spacy.LookupLogger.v1", "patterns": ["test"]}
 """
 
 invalid_config_string = """

--- a/spacy_loggers/tests/test_chain.py
+++ b/spacy_loggers/tests/test_chain.py
@@ -1,0 +1,48 @@
+import pytest
+
+from .util import load_logger_from_config
+
+
+valid_config_string = """
+[nlp]
+lang = "en"
+pipeline = ["tok2vec"]
+
+[components]
+
+[components.tok2vec]
+factory = "tok2vec"
+
+[training]
+
+[training.logger]
+@loggers = "spacy.ChainLogger.v1"
+logger1 = {"@loggers": "spacy.PyTorchLogger.v1"}
+logger2 = {"@loggers": "spacy.ConsoleLogger.v1", "progress_bar": "true"}
+logger9 = {"@loggers": "spacy.ConsoleLogger.v1", "progress_bar": "true"}
+"""
+
+invalid_config_string = """
+[nlp]
+lang = "en"
+pipeline = ["tok2vec"]
+
+[components]
+
+[components.tok2vec]
+factory = "tok2vec"
+
+[training]
+
+[training.logger]
+@loggers = "spacy.ChainLogger.v1"
+"""
+
+
+def test_load_from_config():
+    valid_logger, nlp = load_logger_from_config(valid_config_string)
+    _, _ = valid_logger(nlp)
+
+    with pytest.raises(ValueError, match="No loggers"):
+        invalid_logger, nlp = load_logger_from_config(invalid_config_string)
+        _, _ = invalid_logger(nlp)

--- a/spacy_loggers/tests/test_lookup.py
+++ b/spacy_loggers/tests/test_lookup.py
@@ -1,7 +1,7 @@
 import pytest
 import re
 
-from spacy_loggers.util import setup_custom_stats_matcher
+from spacy_loggers.util import matcher_for_regex_patterns
 from .util import load_logger_from_config
 
 
@@ -61,7 +61,7 @@ def test_load_from_config():
     valid_logger, nlp = load_logger_from_config(valid_config_string)
     _, _ = valid_logger(nlp)
 
-    with pytest.raises(ValueError, match="no patterns"):
+    with pytest.raises(ValueError, match="at least one pattern"):
         invalid_logger, nlp = load_logger_from_config(invalid_config_string_empty)
         _, _ = invalid_logger(nlp)
 
@@ -73,7 +73,7 @@ def test_load_from_config():
 
 
 def test_custom_stats_matcher():
-    patterns = ["^(p|P)ytorch", "zeppelin$"]
+    patterns = ["^[pP]ytorch", "zeppelin$"]
     inputs = [
         "no match",
         "torch",
@@ -84,8 +84,8 @@ def test_custom_stats_matcher():
     ]
     outputs = [False, False, False, True, True, True]
 
-    matcher = setup_custom_stats_matcher(patterns)
+    matcher = matcher_for_regex_patterns(patterns)
     assert [matcher(x) for x in inputs] == outputs
 
     with pytest.raises(ValueError, match="couldn't be compiled"):
-        _ = setup_custom_stats_matcher([")"])
+        _ = matcher_for_regex_patterns([")"])

--- a/spacy_loggers/tests/test_lookup.py
+++ b/spacy_loggers/tests/test_lookup.py
@@ -19,7 +19,7 @@ factory = "tok2vec"
 
 [training.logger]
 @loggers = "spacy.LookupLogger.v1"
-patterns = ["^(p|P)ytorch", "zeppelin" ]
+patterns = ["^[pP]ytorch", "zeppelin" ]
 """
 
 invalid_config_string_empty = """

--- a/spacy_loggers/tests/test_lookup.py
+++ b/spacy_loggers/tests/test_lookup.py
@@ -59,17 +59,17 @@ patterns = [")"]
 
 def test_load_from_config():
     valid_logger, nlp = load_logger_from_config(valid_config_string)
-    _, _ = valid_logger(nlp)
+    valid_logger(nlp)
 
     with pytest.raises(ValueError, match="at least one pattern"):
         invalid_logger, nlp = load_logger_from_config(invalid_config_string_empty)
-        _, _ = invalid_logger(nlp)
+        invalid_logger(nlp)
 
     with pytest.raises(ValueError, match="couldn't be compiled"):
         invalid_logger, nlp = load_logger_from_config(
             invalid_config_string_incorrect_pattern
         )
-        _, _ = invalid_logger(nlp)
+        invalid_logger(nlp)
 
 
 def test_custom_stats_matcher():
@@ -88,4 +88,4 @@ def test_custom_stats_matcher():
     assert [matcher(x) for x in inputs] == outputs
 
     with pytest.raises(ValueError, match="couldn't be compiled"):
-        _ = matcher_for_regex_patterns([")"])
+        matcher_for_regex_patterns([")"])

--- a/spacy_loggers/tests/test_lookup.py
+++ b/spacy_loggers/tests/test_lookup.py
@@ -1,0 +1,91 @@
+import pytest
+import re
+
+from spacy_loggers.util import setup_custom_stats_matcher
+from .util import load_logger_from_config
+
+
+valid_config_string = """
+[nlp]
+lang = "en"
+pipeline = ["tok2vec"]
+
+[components]
+
+[components.tok2vec]
+factory = "tok2vec"
+
+[training]
+
+[training.logger]
+@loggers = "spacy.LookupLogger.v1"
+patterns = ["^(p|P)ytorch", "zeppelin" ]
+"""
+
+invalid_config_string_empty = """
+[nlp]
+lang = "en"
+pipeline = ["tok2vec"]
+
+[components]
+
+[components.tok2vec]
+factory = "tok2vec"
+
+[training]
+
+[training.logger]
+@loggers = "spacy.LookupLogger.v1"
+patterns = []
+"""
+
+invalid_config_string_incorrect_pattern = """
+[nlp]
+lang = "en"
+pipeline = ["tok2vec"]
+
+[components]
+
+[components.tok2vec]
+factory = "tok2vec"
+
+[training]
+
+[training.logger]
+@loggers = "spacy.LookupLogger.v1"
+patterns = [")"]
+"""
+
+
+def test_load_from_config():
+    valid_logger, nlp = load_logger_from_config(valid_config_string)
+    _, _ = valid_logger(nlp)
+
+    with pytest.raises(ValueError, match="no patterns"):
+        invalid_logger, nlp = load_logger_from_config(invalid_config_string_empty)
+        _, _ = invalid_logger(nlp)
+
+    with pytest.raises(ValueError, match="couldn't be compiled"):
+        invalid_logger, nlp = load_logger_from_config(
+            invalid_config_string_incorrect_pattern
+        )
+        _, _ = invalid_logger(nlp)
+
+
+def test_custom_stats_matcher():
+    patterns = ["^(p|P)ytorch", "zeppelin$"]
+    inputs = [
+        "no match",
+        "torch",
+        "pYtorch",
+        "pytorch",
+        "Pytorch 1.13",
+        "led zeppelin",
+    ]
+    outputs = [False, False, False, True, True, True]
+
+    matcher = setup_custom_stats_matcher(patterns)
+    assert [matcher(x) for x in inputs] == outputs
+
+    with pytest.raises(ValueError, match="couldn't be compiled"):
+        _ = setup_custom_stats_matcher([")"])

--- a/spacy_loggers/tests/test_registry.py
+++ b/spacy_loggers/tests/test_registry.py
@@ -8,6 +8,9 @@ FUNCTIONS = [
     ("loggers", "spacy.WandbLogger.v4"),
     ("loggers", "spacy.MLflowLogger.v1"),
     ("loggers", "spacy.ClearMLLogger.v1"),
+    ("loggers", "spacy.ChainLogger.v1"),
+    ("loggers", "spacy.PyTorchLogger.v1"),
+    ("loggers", "spacy.LookupLogger.v1"),
 ]
 
 

--- a/spacy_loggers/tests/util.py
+++ b/spacy_loggers/tests/util.py
@@ -1,0 +1,20 @@
+from typing import Tuple
+
+from spacy import Language
+from spacy.util import (
+    load_model_from_config,
+    registry,
+    load_config_from_str,
+)
+from spacy.schemas import ConfigSchemaTraining
+
+from spacy_loggers.util import LoggerT
+
+
+def load_logger_from_config(config_str: str) -> Tuple[LoggerT, Language]:
+    config = load_config_from_str(config_str)
+    nlp = load_model_from_config(config, auto_fill=True)
+    T = registry.resolve(
+        nlp.config.interpolate()["training"], schema=ConfigSchemaTraining
+    )
+    return T["logger"], nlp

--- a/spacy_loggers/util.py
+++ b/spacy_loggers/util.py
@@ -2,6 +2,7 @@
 Configuration utilities copied from spacy.util.
 """
 from typing import Dict, Any, Tuple, Callable, Iterator, List, Optional, IO
+import re
 
 from spacy import Language
 
@@ -49,3 +50,25 @@ def dict_to_dot(obj: Dict[str, dict]) -> Dict[str, Any]:
     RETURNS (Dict[str, Any]): The key/value pairs.
     """
     return {".".join(key): value for key, value in walk_dict(obj)}
+
+
+def setup_custom_stats_matcher(
+    regexps: Optional[List[str]] = None,
+) -> Callable[[str], bool]:
+    try:
+        compiled = []
+        if compiled is not None:
+            for regex in regexps:
+                compiled.append(re.compile(regex))
+    except:
+        raise ValueError(
+            f"Regular expression `{regex}` couldn't be compiled for logger stats matcher"
+        )
+
+    def is_match(string: str) -> bool:
+        for regex in compiled:
+            if regex.match(string):
+                return True
+        return False
+
+    return is_match

--- a/spacy_loggers/util.py
+++ b/spacy_loggers/util.py
@@ -1,7 +1,15 @@
 """
 Configuration utilities copied from spacy.util.
 """
-from typing import Dict, Any, Iterator, Tuple, List
+from typing import Dict, Any, Tuple, Callable, Iterator, List, Optional, IO
+
+from spacy import Language
+
+
+LoggerT = Callable[
+    [Language, IO, IO],
+    Tuple[Callable[[Optional[Dict[str, Any]]], None], Callable[[], None]],
+]
 
 
 def walk_dict(

--- a/spacy_loggers/util.py
+++ b/spacy_loggers/util.py
@@ -59,15 +59,15 @@ def setup_custom_stats_matcher(
         compiled = []
         if compiled is not None:
             for regex in regexps:
-                compiled.append(re.compile(regex))
-    except:
+                compiled.append(re.compile(regex, flags=re.MULTILINE))
+    except re.error as err:
         raise ValueError(
             f"Regular expression `{regex}` couldn't be compiled for logger stats matcher"
-        )
+        ) from err
 
     def is_match(string: str) -> bool:
         for regex in compiled:
-            if regex.match(string):
+            if regex.search(string):
                 return True
         return False
 

--- a/spacy_loggers/util.py
+++ b/spacy_loggers/util.py
@@ -1,10 +1,12 @@
 """
 Configuration utilities copied from spacy.util.
 """
+import sys
 from typing import Dict, Any, Tuple, Callable, Iterator, List, Optional, IO
 import re
 
 from spacy import Language
+from spacy.util import registry
 
 
 LoggerT = Callable[
@@ -72,3 +74,12 @@ def setup_custom_stats_matcher(
         return False
 
     return is_match
+
+
+def setup_default_console_logger(
+    nlp: "Language", stdout: IO = sys.stdout, stderr: IO = sys.stderr
+) -> Tuple[Callable, Callable]:
+    console_logger = registry.get("loggers", "spacy.ConsoleLogger.v1")
+    console = console_logger(progress_bar=False)
+    console_log_step, console_finalize = console(nlp, stdout, stderr)
+    return console_log_step, console_finalize

--- a/spacy_loggers/util.py
+++ b/spacy_loggers/util.py
@@ -54,12 +54,12 @@ def dict_to_dot(obj: Dict[str, dict]) -> Dict[str, Any]:
     return {".".join(key): value for key, value in walk_dict(obj)}
 
 
-def setup_custom_stats_matcher(
+def matcher_for_regex_patterns(
     regexps: Optional[List[str]] = None,
 ) -> Callable[[str], bool]:
     try:
         compiled = []
-        if compiled is not None:
+        if regexps is not None:
             for regex in regexps:
                 compiled.append(re.compile(regex, flags=re.MULTILINE))
     except re.error as err:


### PR DESCRIPTION
`ChainLogger` - Allows multiple loggers to be daisy-chained. The number of links in the chain is hard-coded as `confection` neither supports second-order resolution of registry functions nor does its parser correctly convert list primitives inside the same. This also interferes with `pydantic` validation, making the following syntax impossible:
```ini
[training.logger]
@loggers = "spacy.ChainLogger.v1"
chain = [ { "@loggers": "spacy.TestLogger.v1", "val": "random"}, { "@loggers": "spacy.ConsoleLogger.v3", "progress_bar": "train"}]
```

`PyTorchLogger` - Queries PyTorch stats and passes them to other loggers. We wanted to track CUDA memory statistics during training/distillation, but there was no straight-forward way to pass that information to the Weights and Biases logger, thus giving rise to logger chaining.

`LookupLogger` - Meant to be used to as a development tool when working with logger interop (wrote it for testing the above two additions).

I still need to add support for tracking arbitrary values in `WandbLogger`, but that'll come in a separate PR.